### PR TITLE
Improvements to questions regarding sex.

### DIFF
--- a/app/views/informant/personal-details.html
+++ b/app/views/informant/personal-details.html
@@ -59,7 +59,8 @@
             },
             items: [
                 { value: "Female", text: "Female" },
-                { value: "Male", text: "Male" }
+                { value: "Male", text: "Male" },
+                { value: "Indeterminate", text: "Indeterminate" }
             ]
         }) }}
 

--- a/app/views/informant/personal-details.html
+++ b/app/views/informant/personal-details.html
@@ -54,10 +54,9 @@
         {{ hmpoRadios(ctx, {
             id: "sex",
             legend: {
-                text: "Were they female or male?",
+                text: "What was their sex at birth?",
                 classes: "govuk-label--m"
             },
-            hint: "This is their sex at birth",
             items: [
                 { value: "Female", text: "Female" },
                 { value: "Male", text: "Male" }

--- a/app/views/informant/sex.html
+++ b/app/views/informant/sex.html
@@ -13,7 +13,8 @@
             hint: "This is their sex when they died",
             items: [
                 { value: "Female", text: "Female" },
-                { value: "Male", text: "Male" }
+                { value: "Male", text: "Male" },
+                { value: "Indeterminate", text: "Indeterminate" }
             ]
         }) }}
 

--- a/app/views/registrar/record-deceaseds-details-edit.html
+++ b/app/views/registrar/record-deceaseds-details-edit.html
@@ -635,7 +635,8 @@
                                 })
                         }
                     },
-                    { value: "Male", text: "Male" }
+                    { value: "Male", text: "Male" },
+                    { value: "Indeterminate", text: "Indeterminate" }
                 ]
             }) }}
 


### PR DESCRIPTION
Two changes here:

* The question "Were they female or male?" is confusing, as per the hint text, this question is actually asking their sex at birth. Just ask "What was their sex at birth?", and remove the hint.

* As noted in [EU Settlement Scheme (interim
guidance): Gender identity and sex
markers on documents](https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/919615/euss-interim-guidance-gender-identity-and-sex-markers-on-documents-v1.0-ext.pdf), although the UK does not currently issue identity documents with sex markers other than female or male, other countries and territories do, and in some cases do so at birth. For such people, there may be no sensible way to classify them as male or female. Further, the NHS has over 100,000 people whose sex on their medical records is listed as "Indeterminate" (unable to be classified as either male or female). As the Births and Deaths Registration Act (as amended) does not state any restrictions on allowable values for sex, an alternative should be provided to handle these instances.

I have used "Indeterminate" here, but I note that the UK government does not currently have a consistent term, using "Unspecified", "Not Specified", or "Indeterminate" in various systems - all of which seem acceptable options. Some systems also have a "Not Known" option which may be appropriate to add as well.