### PR TITLE
Fix authentication for Heroku

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -10,7 +10,7 @@ module.exports = {
     port: '3000',
 
     // Enable or disable password protection on production
-    useAuth: 'false',
+    useAuth: 'true',
 
     // Enable cookie-based session store (persists on restart)
     // Please note 4KB cookie limit per domain, cookies too large will silently be ignored


### PR DESCRIPTION
- Revert change for `useAuth` and re-enable