### PR TITLE
Digital certification reform alterations

### DIFF
--- a/app/views/registrar/check-your-email.html
+++ b/app/views/registrar/check-your-email.html
@@ -7,7 +7,7 @@
 
     {% call hmpoForm(ctx) %}
 
-        <p>Enter the 6 digit code we’ve sent to your LRS email address.
+        <p>Enter the 6 digit code we’ve sent to your work email address.
 
         It might take a minute or so to arrive. If you do not use it within 5 minutes, you’ll need to get a new code.</p>
 

--- a/app/views/registrar/record-cause-of-death-edit.html
+++ b/app/views/registrar/record-cause-of-death-edit.html
@@ -75,7 +75,7 @@
             classes: "govuk-radios--small",
             items: [
                 {
-                    value: "Medical certificate",
+                    value: "Attending practitioner certificate (standard)",
                     text: "Attending practitioner certificate (standard)",
                     conditional: {
                         html:
@@ -89,7 +89,7 @@
                     }
                 },
                 {
-                    value: "Medical examiner certificate",
+                    value: "Medical examiner certificate (standard)",
                     text: "Medical examiner certificate (standard)",
                     conditional: {
                         html:
@@ -515,7 +515,7 @@
 
         <script>
             document.addEventListener("DOMContentLoaded", function () {
-                const medicalCertificateRadio = document.querySelector('input[value="AP certificate"]');
+                const medicalCertificateRadio = document.querySelector('input[value="Medical certificate"]');
                 const medicalExaminerCertificateRadio = document.querySelector('input[value="Medical examiner certificate"]');
                 const conditionalRevealAttendingPractitionerFieldset = document.getElementById("conditionalRevealAttendingPractitionerFieldset");
 

--- a/app/views/registrar/record-cause-of-death-edit.html
+++ b/app/views/registrar/record-cause-of-death-edit.html
@@ -76,7 +76,7 @@
             items: [
                 {
                     value: "Medical certificate",
-                    text: "Medical certificate",
+                    text: "Attending practitioner certificate (standard)",
                     conditional: {
                         html:
                             hmpoText(ctx, {
@@ -90,7 +90,7 @@
                 },
                 {
                     value: "Medical examiner certificate",
-                    text: "Medical examiner certificate",
+                    text: "Medical examiner certificate (standard)",
                     conditional: {
                         html:
                             hmpoText(ctx, {
@@ -217,32 +217,7 @@
 
         <p><a href="#">2. Add other significant contributory conditions</a></p>
 
-        {{ hmpoRadios(ctx, {
-            id: "MCCDDidDeceasedHaveAnyHazardousImplants",
-            legend: {
-                text: "Did the deceased have any hazardous implants?",
-                classes: "govuk-label--s"
-            },
-            hint: "For example, a pacemaker or radioactive device",
-            classes: "govuk-radios--small",
-            items: [
-                {
-                    value: true,
-                    conditional: {
-                        html: MCCDHazardousImplantsReveal
-                    }
-                },
-                {
-                    value: false
-                },
-                {
-                    value: "unknown",
-                    text: "Not known"
-                }
-            ]
-        }) }}
-
-        {{ hmpoRadios(ctx, {
+       {{ hmpoRadios(ctx, {
             id: "MCCDDiedInHospital",
             legend: {
                 text: "Died in a hospital?",
@@ -268,6 +243,35 @@
             }
         ]
         }) }}
+       
+       
+       
+        {{ hmpoRadios(ctx, {
+            id: "MCCDDidDeceasedHaveAnyHazardousImplants",
+            legend: {
+                text: "Did the deceased have any hazardous implants?",
+                classes: "govuk-label--s"
+            },
+            hint: "For example, a pacemaker or radioactive device",
+            classes: "govuk-radios--small",
+            items: [
+                {
+                    value: true,
+                    conditional: {
+                        html: MCCDHazardousImplantsReveal
+                    }
+                },
+                {
+                    value: false
+                },
+                {
+                    value: "unknown",
+                    text: "Not known"
+                }
+            ]
+        }) }}
+
+        
 
         {{ hmpoRadios(ctx, {
             id: "MCCDPregnancy",
@@ -511,7 +515,7 @@
 
         <script>
             document.addEventListener("DOMContentLoaded", function () {
-                const medicalCertificateRadio = document.querySelector('input[value="Medical certificate"]');
+                const medicalCertificateRadio = document.querySelector('input[value="AP certificate"]');
                 const medicalExaminerCertificateRadio = document.querySelector('input[value="Medical examiner certificate"]');
                 const conditionalRevealAttendingPractitionerFieldset = document.getElementById("conditionalRevealAttendingPractitionerFieldset");
 

--- a/app/views/registrar/record-cause-of-death.html
+++ b/app/views/registrar/record-cause-of-death.html
@@ -138,7 +138,7 @@
                     value: { html:
                         MCCDAttendingPractitionerDetails if MCCDAttendingPractitionerDetails else "<br><br><br>"
                     }
-                } if values.MCCDWhereMedicalInformationFrom === 'Medical certificate',
+                } if values.MCCDWhereMedicalInformationFrom === 'Attending practitioner certificate (standard)',
                 {
                     key: { text: "Medical examiner details" },
                     value: { html:

--- a/app/views/registrar/record-edit.html
+++ b/app/views/registrar/record-edit.html
@@ -76,7 +76,7 @@
     {{ hmpoDate(ctx, {
         id: "coverSheetDateMCCDReceived",
         legend: {
-            text: "Date MCCD received",
+            text: "Date medical certificate received",
             classes: "govuk-label--s"
         },
         hint: "For example, 12 11 2007"
@@ -85,7 +85,7 @@
     {{ hmpoRadios(ctx, {
         id: "coverSheetMCCDStatus",
         legend: {
-            text: "MCCD status",
+            text: "Medical certificate status",
             classes: "govuk-label--s"
         },
         classes: "govuk-radios--small",

--- a/app/views/registrar/record-informants-details-edit.html
+++ b/app/views/registrar/record-informants-details-edit.html
@@ -2,24 +2,21 @@
 
 {% set hmpoTitle %}{{values.coverSheetDeceasedLastName | upper}}, {{values.coverSheetDeceasedFirstName}}{% endset %}
 
-{% set informantQualificationRelativeOrPartnerReveal %}
+{% set informantQualificationRelative %}
     {% from "hmpo-radios/macro.njk" import hmpoRadios %}
     {% from "hmpo-text/macro.njk" import hmpoText %}
 
     {{ hmpoRadios(ctx, {
         id: "informantQualificationAdditional",
         legend: {
-            text: "Relative or partner qualification",
+            text: "Relative qualification",
             classes: "govuk-label--s govuk-visually-hidden"
         },
         classes: "govuk-radios--small",
         items: [
-            { value: "Relative present at death", text: "Relative – present at death" },
-            { value: "Relative in attendance", text: "Relative – in attendance" },
-            { value: "Relative not present at death", text: "Relative – not present at death" },
-            { value: "Partner present at death", text: "Partner – present at death" },
-            { value: "Partner in attendance", text: "Partner – in attendance" },
-            { value: "Partner not present at death", text: "Partner – not present at death" }
+            { value: "Relative present at death", text: "Present at death" },
+            { value: "Relative in attendance", text: "In attendance" },
+            { value: "Relative not present at death", text: "Not present at death" }
         ]
     }) }}
 
@@ -31,6 +28,28 @@
         }
     }) }}
 {% endset %}
+
+{% set informantQualificationPartner %}
+    {% from "hmpo-radios/macro.njk" import hmpoRadios %}
+    {% from "hmpo-text/macro.njk" import hmpoText %}
+
+    {{ hmpoRadios(ctx, {
+        id: "informantQualificationAdditional",
+        legend: {
+            text: "Partner qualification",
+            classes: "govuk-label--s govuk-visually-hidden"
+        },
+        classes: "govuk-radios--small",
+        items: [
+            { value: "Partner present at death", text: "Present at death" },
+            { value: "Partner in attendance", text: "In attendance" },
+            { value: "Partner not present at death", text: "Not present at death" }
+        ]
+    }) }}
+
+    
+{% endset %}
+
 
 {% set informantAddress %}
     {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
@@ -175,10 +194,17 @@
         classes: "govuk-radios--small",
         items: [
             {
-                value: "Relative or partner",
-                text: "Relative or partner",
+                value: "Relative",
+                text: "Relative",
                 conditional: {
-                    html: informantQualificationRelativeOrPartnerReveal
+                    html: informantQualificationRelative
+                }
+            },
+             {
+                value: "Partner",
+                text: "Partner",
+                conditional: {
+                    html: informantQualificationPartner
                 }
             },
             {
@@ -194,13 +220,13 @@
                             },
                             classes: "govuk-radios--small",
                             items: [
-                                { value: "Non-relative present at death", text: "Non-relative – present at death" },
-                                { value: "Non-relative occupier", text: "Non-relative – occupier" },
-                                { value: "Non-relative inmate", text: "Non-relative – inmate" },
-                                { value: "Non-relative causing the body to be buried", text: "Non-relative – causing the body to be buried" },
-                                { value: "Non-relative causing the body to be cremated", text: "Non-relative – causing the body to be cremated" },
-                                { value: "Non-relative in charge of the body", text: "Non-relative – in charge of the body" },
-                                { value: "Non-relative causing the disposal of the body", text: "Non-relative – causing the disposal of the body" },
+                                { value: "Non-relative present at death", text: "Present at death" },
+                                { value: "Non-relative occupier", text: "Occupier" },
+                                { value: "Non-relative inmate", text: "Inmate" },
+                                { value: "Non-relative causing the body to be buried", text: "Causing the body to be buried" },
+                                { value: "Non-relative causing the body to be cremated", text: "Causing the body to be cremated" },
+                                { value: "Non-relative in charge of the body", text: "In charge of the body" },
+                                { value: "Non-relative causing the disposal of the body", text: "Causing the disposal of the body" },
                                 { value: "Non-relative personal representative of the deceased", text: "Personal representative of the deceased" }
                             ]
                         })

--- a/app/views/registrar/record-informants-details.html
+++ b/app/views/registrar/record-informants-details.html
@@ -80,7 +80,7 @@
         {
             key: { text: "Qualification" },
             value: {
-                text: "Relative – present at death" if values.informantQualificationAdditional == "Relative present at death"
+                text: "Relative - present at death" if values.informantQualificationAdditional == "Relative present at death"
                     else ("Relative – in attendance" if values.informantQualificationAdditional == "Relative in attendance"
                         else ("Relative – not present at death" if values.informantQualificationAdditional == "Relative not present at death"
                             else ("Partner – present at death" if values.informantQualificationAdditional == "Partner present at death"

--- a/app/views/registrar/record.html
+++ b/app/views/registrar/record.html
@@ -31,7 +31,7 @@
     <h3 class="govuk-heading-m">File information</h3>
     {{ govukSummaryList({ rows: [
         {
-            key: { text: "Date medical certificate was issued" },
+            key: { text: "Date medical certificate issued" },
             value: { text: values.MCCDDateMedicalCertificateIssued | date("DD/MM/YYYY") }
         },
         {

--- a/app/views/registrar/sign-in.html
+++ b/app/views/registrar/sign-in.html
@@ -15,7 +15,7 @@
                 text: "Email address",
                 classes: "govuk-label--s"
             },
-            hint: "This is your LRS email address"
+            hint: "This is your work email address"
         }) }}
 
         {{ hmpoText(ctx, {


### PR DESCRIPTION
Altered to change wording for the 2 MCCDs to Attending practitioner certificate (standard) and Medical examiner certificate (standard).

Altered the informant radios to split out relative and partner. 

Removed reference to LRS and changed to work. 